### PR TITLE
Fix server-set types

### DIFF
--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -2,18 +2,23 @@ import type { Exact } from "type-fest";
 import type { HasAllKeysOfRelated } from "../helpers.ts";
 import type {
   Email,
+  EmailCreate,
   EmailFilterCondition,
   EmailImport,
   EmailSubmission,
+  EmailSubmissionCreate,
   EmailSubmissionFilterCondition,
   GetValueFromHeaderKey,
   HeaderFieldKey,
   Identity,
+  IdentityCreate,
   Mailbox,
+  MailboxCreate,
   MailboxFilterCondition,
   SearchSnippet,
   Thread,
-  VacationResponse
+  VacationResponse,
+  VacationResponseCreate
 } from "./jmap-mail.ts";
 import type {
   BlobCopyArguments,
@@ -30,6 +35,8 @@ import type {
   Request as JMAPRequest,
   Response as JMAPResponse,
   ProblemDetails,
+  PushSubscription,
+  PushSubscriptionCreate,
   QueryArguments,
   QueryChangesArguments,
   QueryChangesResponse,
@@ -47,7 +54,7 @@ export type Requests = {
   // Push Subscription ----------------------
   "PushSubscription/get": Omit<GetArguments<PushSubscription>, "accountId">;
   "PushSubscription/set": Omit<
-    SetArguments<PushSubscription>,
+    SetArguments<PushSubscriptionCreate>,
     "accountId" | "ifInState"
   >;
   // Mailbox --------------------------------
@@ -61,7 +68,7 @@ export type Requests = {
     Mailbox,
     MailboxFilterCondition
   >;
-  "Mailbox/set": SetArguments<Mailbox> & {
+  "Mailbox/set": SetArguments<MailboxCreate> & {
     onDestroyRemoveEmails?: boolean;
   };
   // Thread ---------------------------------
@@ -76,7 +83,7 @@ export type Requests = {
   "Email/queryChanges": QueryChangesArguments<Email, EmailFilterCondition> & {
     collapseThreads?: boolean;
   };
-  "Email/set": SetArguments<Omit<Email, "headers">>;
+  "Email/set": SetArguments<EmailCreate>;
   "Email/copy": CopyArguments<
     Pick<Email, "id" | "mailboxIds" | "keywords" | "receivedAt">
   >;
@@ -107,7 +114,7 @@ export type Requests = {
   // Identity -------------------------------
   "Identity/get": GetArguments<Identity>;
   "Identity/changes": ChangesArguments;
-  "Identity/set": SetArguments<Identity>;
+  "Identity/set": SetArguments<IdentityCreate>;
   // Email Submission -----------------------
   "EmailSubmission/get": GetArguments<EmailSubmission>;
   "EmailSubmission/changes": ChangesArguments;
@@ -119,13 +126,13 @@ export type Requests = {
     EmailSubmission,
     EmailSubmissionFilterCondition
   >;
-  "EmailSubmission/set": SetArguments<EmailSubmission> & {
+  "EmailSubmission/set": SetArguments<EmailSubmissionCreate> & {
     onSuccessUpdateEmail?: Record<ID, Partial<Email>> | null;
     onSuccessDestroyEmail?: ID[] | null;
   };
   // Vacation Response ----------------------
   "VacationResponse/get": GetArguments<VacationResponse>;
-  "VacationResponse/set": SetArguments<VacationResponse>;
+  "VacationResponse/set": SetArguments<VacationResponseCreate>;
 };
 
 export type Methods = keyof Requests;

--- a/src/types/jmap-mail.ts
+++ b/src/types/jmap-mail.ts
@@ -1,4 +1,3 @@
-import type { OmitDeep } from "type-fest";
 import type { FilterCondition, ID, UTCDate } from "./jmap.ts";
 
 /**
@@ -367,7 +366,7 @@ export type ForbiddenKeywordCharacters =
  * [rfc8621 § 4.1.2.3](https://datatracker.ietf.org/doc/html/rfc8621#section-4.1.2.3)
  */
 export type EmailAddress = {
-  name: string | null;
+  name?: string;
   email: string;
 };
 
@@ -375,7 +374,7 @@ export type EmailAddress = {
  * [rfc8621 § 4.1.2.4](https://datatracker.ietf.org/doc/html/rfc8621#section-4.1.2.4)
  */
 export type EmailAddressGroup = {
-  name: string | null;
+  name?: string;
   addresses: EmailAddress[];
 };
 
@@ -442,11 +441,11 @@ export type HeaderParsedForm = {
    * or folding white space (CFWS) and surrounding angle brackets ("<>")
    * are removed.  If parsing fails, the value is null.
    */
-  MessageIds: string[] | null;
+  MessageIds?: string[];
   /**
    * [rfc8621 § 4.1.2.6](https://datatracker.ietf.org/doc/html/rfc8621#section-4.1.2.6)
    */
-  Date: string | null;
+  Date?: string;
   /**
    * [rfc8621 § 4.1.2.7](https://datatracker.ietf.org/doc/html/rfc8721#section-4.1.2.6)
    *
@@ -455,7 +454,7 @@ export type HeaderParsedForm = {
    * surrounding angle brackets or any comments in the header field with
    * the URLs.  If parsing fails, the value is null.
    */
-  URLs: string[] | null;
+  URLs?: string[];
 };
 
 /**
@@ -512,47 +511,47 @@ type EmailHeaderFields = {
    * The value is identical to the value of `header:Message-ID:asMessageIds`.
    * For messages conforming to RFC 5322, this will be an array with a single entry.
    */
-  messageId: string[] | null;
+  messageId?: string[];
   /**
    * The value is identical to the value of `header:In-Reply-To:asMessageIds`.
    */
-  inReplyTo: string[] | null;
+  inReplyTo?: string[];
   /**
    * The value is identical to the value of `header:References:asMessageIds`.
    */
-  references: string[] | null;
+  references?: string[];
   /**
    * The value is identical to the value of `header:Sender:asAddresses`.
    */
-  sender: EmailAddress[] | null;
+  sender?: EmailAddress[];
   /**
    * The value is identical to the value of `header:From:asAddresses`.
    */
-  from: EmailAddress[] | null;
+  from?: EmailAddress[];
   /**
    * The value is identical to the value of `header:To:asAddresses`.
    */
-  to: EmailAddress[] | null;
+  to?: EmailAddress[];
   /**
    * The value is identical to the value of `header:Cc:asAddresses`.
    */
-  cc: EmailAddress[] | null;
+  cc?: EmailAddress[];
   /**
    * The value is identical to the value of `header:Bcc:asAddresses`.
    */
-  bcc: EmailAddress[] | null;
+  bcc?: EmailAddress[];
   /**
    * The value is identical to the value of `header:Reply-To:asAddresses`.
    */
-  replyTo: EmailAddress[] | null;
+  replyTo?: EmailAddress[];
   /**
    * The value is identical to the value of `header:Subject:asText`.
    */
-  subject: string | null;
+  subject?: string;
   /**
    * The value is identical to the value of `header:Date:asDate`.
    */
-  sentAt: string | null;
+  sentAt?: string;
 };
 
 /**
@@ -565,7 +564,7 @@ export type EmailBodyPart = {
    * representation.  This is null if, and only if, the part is of type
    * `multipart/*`.
    */
-  partId: ID | null;
+  partId?: ID;
   /**
    * The id representing the raw octets of the contents of the part,
    * after decoding any known Content-Transfer-Encoding (as defined in
@@ -576,7 +575,7 @@ export type EmailBodyPart = {
    * the blob id.  If the transfer encoding is unknown, it is treated
    * as though it had no transfer encoding.
    */
-  blobId: ID | null;
+  blobId?: ID;
   /**
    * The size, in octets, of the raw data after content transfer
    * decoding (as referenced by the `blobId`, i.e., the number of
@@ -594,7 +593,7 @@ export type EmailBodyPart = {
    * existing systems) if not present, then it's the decoded `name`
    * parameter of the Content-Type header field per [RFC2047].
    */
-  name: string | null;
+  name?: string;
   /**
    * The value of the Content-Type header field of the part, if
    * present; otherwise, the implicit type as per the MIME standard
@@ -609,13 +608,13 @@ export type EmailBodyPart = {
    * exists and is of type `text/*` but has no charset parameter, this
    * is the implicit charset as per the MIME standard: `us-ascii`.
    */
-  charset: string | null;
+  charset?: string;
   /**
    * The value of the Content-Disposition header field of the part, if
    * present; otherwise, it's null.  CFWS is removed and any parameters
    * are stripped.
    */
-  disposition: string | null;
+  disposition?: string;
   /**
    * The value of the Content-Id header field of the part, if present;
    * otherwise, it's null.  CFWS and surrounding angle brackets ("<>")
@@ -623,22 +622,22 @@ export type EmailBodyPart = {
    * within a "text/html" body part [HTML](https://datatracker.ietf.org/doc/html/rfc8621#ref-HTML) using the "cid:" protocol,
    * as defined in [RFC2392].
    */
-  cid: string | null;
+  cid?: string;
   /**
    * The list of language tags, as defined in [RFC3282], in the
    * Content-Language header field of the part, if present.
    */
-  language: string[] | null;
+  language?: string[];
   /**
    * The URI, as defined in [RFC2557], in the Content-Location header
    * field of the part, if present.
    */
-  location: string | null;
+  location?: string;
   /**
    * If the type is "multipart/*", this contains the body parts of each
    * child.
    */
-  subParts: EmailBodyPart[] | null;
+  subParts?: EmailBodyPart[];
 };
 
 /**
@@ -934,7 +933,7 @@ export type SearchSnippet = {
    * If the subject does not match text from the filter, this property
    * is null.
    */
-  subject: string | null;
+  subject?: string;
   /**
    * If text from the filter matches the plaintext or HTML body, this
    * is the relevant section of the body (converted to plaintext if
@@ -943,7 +942,7 @@ export type SearchSnippet = {
    * body does not contain a match for the text from the filter, this
    * property is null.
    */
-  preview: string | null;
+  preview?: string;
 };
 
 // =================================
@@ -983,12 +982,12 @@ export type Identity = {
    * The Reply-To value the client SHOULD set when creating a new Email
    * from this Identity.
    */
-  replyTo: EmailAddress[] | null;
+  replyTo?: EmailAddress[];
   /**
    * The Bcc value the client SHOULD set when creating a new Email from
    * this Identity.
    */
-  bcc: EmailAddress[] | null;
+  bcc?: EmailAddress[];
   /**
    * A signature the client SHOULD insert into new plaintext messages
    * that will be sent from this Identity.  Clients MAY ignore this
@@ -1088,7 +1087,7 @@ export type EmailSubmission = {
    *
    * @kind server-set
    */
-  deliveryStatus: Record<string, DeliveryStatus> | null;
+  deliveryStatus?: Record<string, DeliveryStatus>;
   /**
    * A list of blob ids for DSNs [RFC3464] received for this
    * submission, in order of receipt, oldest first.  The blob is the
@@ -1325,20 +1324,20 @@ export type VacationResponse = {
    * user's vacation response.  If null, the vacation response is
    * effective immediately.
    */
-  fromDate: UTCDate | null;
+  fromDate?: UTCDate;
   /**
    * If `isEnabled` is true, messages that arrive before this date-time
    * (but on or after the `fromDate` if defined) should receive the
    * user's vacation response.  If null, the vacation response is
    * effective indefinitely.
    */
-  toDate: UTCDate | null;
+  toDate?: UTCDate;
   /**
    * The subject that will be used by the message sent in response to
    * messages when the vacation response is enabled.  If null, an
    * appropriate subject SHOULD be set by the server.
    */
-  subject: string | null;
+  subject?: string;
   /**
    * The plaintext body to send in response to messages when the
    * vacation response is enabled.  If this is null, the server SHOULD
@@ -1347,7 +1346,7 @@ export type VacationResponse = {
    * only.  If both "textBody" and "htmlBody" are null, an appropriate
    * default body SHOULD be generated for responses by the server.
    */
-  textBody: string | null;
+  textBody?: string;
   /**
    * The HTML body to send in response to messages when the vacation
    * response is enabled.  If this is null, the server MAY choose to
@@ -1355,7 +1354,7 @@ export type VacationResponse = {
    * vacation responses or MAY choose to send the response as plaintext
    * only.
    */
-  htmlBody: string | null;
+  htmlBody?: string;
 };
 
 export type VacationResponseCreate = Omit<VacationResponse, "id">;

--- a/src/types/jmap-mail.ts
+++ b/src/types/jmap-mail.ts
@@ -961,7 +961,7 @@ export type EmailSubmission = {
   /**
    * Information for use when sending via SMTP.
    */
-  envelope: Envelope | null;
+  envelope?: Envelope;
   /**
    * The date the submission was/will be released for delivery.  If the
    * client successfully used FUTURERELEASE [RFC4865] with the
@@ -1044,7 +1044,7 @@ export type EmailSubmissionAddress = {
    * (see [RFC3461] and [RFC6533]) and JSON string encoding is
    * applied.
    */
-  parameters: Record<string, unknown> | null;
+  parameters?: Record<string, unknown>;
 };
 
 /**

--- a/src/types/jmap.ts
+++ b/src/types/jmap.ts
@@ -680,9 +680,7 @@ export type SetArguments<T extends object> = {
  *
  * TODO: Support more correct types for PatchObject
  */
-export type PatchObject<T> = {
-  [key in ExtendedJSONPointer | keyof T]: Partial<T>;
-};
+export type PatchObject<T> = Partial<T> | { [K in ExtendedJSONPointer]: any };
 
 export type SetResponse<T> = {
   /**

--- a/src/types/jmap.ts
+++ b/src/types/jmap.ts
@@ -26,6 +26,11 @@ import type { Obj } from "../helpers.ts";
 export type ID = string;
 
 /**
+ * An arbitrary string defined by the client, used to identify created records
+ */
+export type CreationID = string;
+
+/**
  * [rfc8620 § 1.4](https://datatracker.ietf.org/doc/html/rfc8620#section-1.4)
  *
  * Where "Date" is given as a type, it means a string in "date-time"
@@ -629,7 +634,7 @@ export enum ChangesRequestErrorType {
 /**
  * [rfc8620 § 5.3](https://datatracker.ietf.org/doc/html/rfc8620#section-5.3)
  */
-export type SetArguments<T> = {
+export type SetArguments<T extends object> = {
   /**
    * The id of the account to use.
    */
@@ -653,7 +658,7 @@ export type SetArguments<T> = {
    * The client MUST omit any properties that may only be set by the
    * server (for example, the `id` property on most object types).
    */
-  create?: Record<ID, T>;
+  create?: Record<CreationID, T>;
   /**
    * A map of an id to a PatchObject to apply to the current `T`
    * object with that id, or null if no objects are to be updated.
@@ -1439,6 +1444,9 @@ export type TypeState = Record<string, string>;
 export type PushSubscription = {
   /**
    * The id of the push subscription.
+   *
+   * @kind immutable
+   * @kind server-set
    */
   id: ID;
   /**
@@ -1460,19 +1468,25 @@ export type PushSubscription = {
    *
    * To protect the privacy of the user, the `deviceClientId` id MUST NOT
    * contain an unobfuscated device id.
+   *
+   * @kind immutable
    */
   deviceClientId: string;
   /**
    * An absolute URL where the JMAP server will POST the data for the
    * push message.  This MUST begin with `https://`.
+   *
+   * @kind immutable
    */
   url: string;
   /**
    * Client-generated encryption keys.  If supplied, the server MUST
    * use them as specified in [RFC8291] to encrypt all data sent to the
    * push subscription.
+   *
+   * @kind immutable
    */
-  keys?: null | {
+  keys?: {
     /**
      * The P-256 Elliptic Curve Diffie-Hellman (ECDH) public key as
      * described in [RFC8291], encoded in URL-safe base64
@@ -1513,6 +1527,8 @@ export type PushSubscription = {
    */
   types?: string[];
 };
+
+export type PushSubscriptionCreate = Omit<PushSubscription, "id">;
 
 /**
  * [rfc8620 § 7.2.2](https://datatracker.ietf.org/doc/html/rfc8620#section-7.2.2)

--- a/src/types/jmap.ts
+++ b/src/types/jmap.ts
@@ -487,7 +487,7 @@ export type GetArguments<T> = {
    * type and the number of records does not exceed the
    * `maxObjectsInGet` limit.
    */
-  ids?: ReadonlyArray<ID> | null;
+  ids?: ReadonlyArray<ID>;
   /**
    *  If supplied, only the properties listed in the array are returned
    * for each `T` object.  If null, all properties of the object are
@@ -496,7 +496,7 @@ export type GetArguments<T> = {
    * requested, the call MUST be rejected with an "invalidArguments"
    * error.
    */
-  properties?: ReadonlyArray<keyof T> | null;
+  properties?: ReadonlyArray<keyof T>;
 };
 
 export type GetResponse<T, Args> = Args extends GetArguments<T>
@@ -574,7 +574,7 @@ export type ChangesArguments = {
    * is given, the server MUST reject the call with an
    * `invalidArguments` error.
    */
-  maxChanges: number | null;
+  maxChanges?: number;
 };
 
 export type ChangesResponse = {
@@ -642,7 +642,7 @@ export type SetArguments<T> = {
    * returned.  If null, any changes will be applied to the current
    * state.
    */
-  ifInState: string | null;
+  ifInState?: string;
   /**
    * A map of a *creation id* (a temporary id set by the client) to `T`
    * objects, or null if no objects are to be created.
@@ -653,13 +653,13 @@ export type SetArguments<T> = {
    * The client MUST omit any properties that may only be set by the
    * server (for example, the `id` property on most object types).
    */
-  create: Record<ID, T> | null;
+  create?: Record<ID, T>;
   /**
    * A map of an id to a PatchObject to apply to the current `T`
    * object with that id, or null if no objects are to be updated.
    */
-  update: PatchObject<T> | null;
-  destroy: ID[] | null;
+  update?: PatchObject<T>;
+  destroy?: ID[];
 };
 
 /**
@@ -863,7 +863,7 @@ export type CopyArguments<T extends { id: ID }> = {
    * `stateMismatch` error returned.  If null, the data will be read
    * from the current state.
    */
-  ifFromInState: string | null;
+  ifFromInState?: string;
   /**
    * The id of the account to copy records to.  This MUST be different
    * to the `fromAccountId`.
@@ -876,7 +876,7 @@ export type CopyArguments<T extends { id: ID }> = {
    * and a `stateMismatch` error returned.  If null, any changes will
    * be applied to the current state.
    */
-  ifInState: string | null;
+  ifInState?: string;
   /**
    * A map of the *creation id* to a `T` object.  The `T` object MUST
    * contain an `id` property, which is the id (in the fromAccount) of
@@ -884,7 +884,7 @@ export type CopyArguments<T extends { id: ID }> = {
    * properties included are used instead of the current value for that
    * property on the original.
    */
-  create: Record<ID, T> | null;
+  create: Record<ID, T>;
   /**
    * If true, an attempt will be made to destroy the original records
    * that were successfully copied: after emitting the "T/copy"
@@ -899,7 +899,7 @@ export type CopyArguments<T extends { id: ID }> = {
    * implicit "T/set" call, if made at the end of this request to
    * destroy the originals that were successfully copied.
    */
-  destroyFromIfInState: string | null;
+  destroyFromIfInState?: string;
 };
 
 export type CopyResponse<T> = {
@@ -985,7 +985,7 @@ export type QueryArguments<T extends Obj, Filter extends Obj = T> = {
    * Determines the set of T objects returned in the results.  If null, all
    * objects in the account of this type are included in the results.
    */
-  filter?: FilterOperator<Filter> | FilterCondition<Filter> | null;
+  filter?: FilterOperator<Filter> | FilterCondition<Filter>;
   /**
    * Lists the names of properties to compare between two `T` records,
    * and how to compare them, to determine which comes first in the
@@ -996,7 +996,7 @@ export type QueryArguments<T extends Obj, Filter extends Obj = T> = {
    * order is server dependent, but it MUST be stable between calls to
    * "T/query".
    */
-  sort?: ReadonlyArray<Comparator<T>> | null;
+  sort?: ReadonlyArray<Comparator<T>>;
   /**
    * The zero-based index of the first id in the full list of results
    * to return.
@@ -1018,7 +1018,7 @@ export type QueryArguments<T extends Obj, Filter extends Obj = T> = {
    * the `anchorOffset` argument to determine the index of the first
    * result to return
    */
-  anchor?: string | null;
+  anchor?: string;
   /**
    * The index of the first result to return relative to the index of
    * the anchor, if an anchor is given.  This MAY be negative.  For
@@ -1035,7 +1035,7 @@ export type QueryArguments<T extends Obj, Filter extends Obj = T> = {
    * value is given, the call MUST be rejected with an
    * `invalidArguments` error.
    */
-  limit?: number | null;
+  limit?: number;
   /**
    * Does the client wish to know the total number of results in the
    * query?  This may be slow and expensive for servers to calculate,
@@ -1141,11 +1141,11 @@ export type QueryChangesArguments<T extends Obj, Filter extends Obj> = {
   /**
    * The filter argument that was used with "T/query".
    */
-  filter: FilterOperator<Filter> | FilterCondition<Filter> | null;
+  filter?: FilterOperator<Filter> | FilterCondition<Filter>;
   /**
    * The sort argument that was used with "T/query".
    */
-  sort: ReadonlyArray<Comparator<T>> | null;
+  sort?: ReadonlyArray<Comparator<T>>;
   /**
    * The current state of the query in the client.  This is the string
    * that was returned as the `queryState` argument in the "T/query"
@@ -1157,7 +1157,7 @@ export type QueryChangesArguments<T extends Obj, Filter extends Obj> = {
    * The maximum number of changes to return in the response.  See
    * error descriptions below for more details.
    */
-  maxChanges: number | null;
+  maxChanges?: number;
   /**
    * The last (highest-index) id the client currently has cached from
    * the query results.  When there are a large number of results, in a
@@ -1168,7 +1168,7 @@ export type QueryChangesArguments<T extends Obj, Filter extends Obj> = {
    * significantly increase efficiency.  If they are not immutable,
    * this argument is ignored.
    */
-  upToId: ID | null;
+  upToId?: ID;
   /**
    * Does the client wish to know the total number of results now in
    * the query?  This may be slow and expensive for servers to
@@ -1491,7 +1491,7 @@ export type PushSubscription = {
    * a push message, and the client updates the PushSubscription object
    * with the code; see Section 7.2.2 for details.
    */
-  verificationCode?: string | null;
+  verificationCode?: string;
   /**
    * The time this push subscription expires.  If specified, the JMAP
    * server MUST NOT make further requests to this resource after this
@@ -1502,7 +1502,7 @@ export type PushSubscription = {
    * client or modify the expiry time given by the client to a shorter
    * duration.
    */
-  expires?: UTCDate | null;
+  expires?: UTCDate;
   /**
    * A list of types the client is interested in (using the same names
    * as the keys in the TypeState object defined in the previous
@@ -1511,7 +1511,7 @@ export type PushSubscription = {
    * the TypeState object.  If null, changes will be pushed for all
    * types.
    */
-  types?: string[] | null;
+  types?: string[];
 };
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,9 +13,7 @@
     "outDir": "dist",
     "declarationMap": true,
     "noUnusedLocals": true,
-    "types": [
-      "vitest/importMeta"
-    ]
+    "types": ["vitest/importMeta"]
   },
   "include": ["src/**/*"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,8 +3,8 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     typecheck: {
-      enabled: true,
+      enabled: true
     },
-    includeSource: ["src/**/*.ts"],
-  },
+    includeSource: ["src/**/*.ts"]
+  }
 });


### PR DESCRIPTION
## Changes

- Adjust nullable values to use optional field modifiers instead.
- Annotate immutable and server-set fields with JSDoc comments.
- Update `*/set` arguments to omit server-set fields.
- Widen `Email/set` arguments to make all fields optional ([RFC8621 § 4.6](https://datatracker.ietf.org/doc/html/rfc8621#section-4.6) is a little unclear here and I want to revisit this soon).
- Fix missing `PushSubscription` type import.

Fixes #15.