### PR TITLE
Expose RequestOptions argument in API methods

### DIFF
--- a/packages/jmap-jam/src/__test__/client.test-d.ts
+++ b/packages/jmap-jam/src/__test__/client.test-d.ts
@@ -107,8 +107,8 @@ describe("Email", () => {
     } */
   });
 
-  it("allows passing RequestOptions to API methods", () => {
-    jam.api.Email.get(
+  it("allows passing RequestOptions to API methods", async () => {
+    await jam.api.Email.get(
       {
         accountId: "123"
       },


### PR DESCRIPTION
This PR exposes the `RequestOptions` parameter in the `ProxyAPI` type so that I can manually specify the scopes with the `using` property.

I am trying to use this library to interact with the Fastmail JMAP API and need to specify the `urn:ietf:params:jmap:core` scope for every request. Whilst I don't think this scope is explicitly required according to the RFC, the Fastmail devs seem to have interpreted that way. I did consider updating the code to automatically send it for every request by default, but felt that warranted a discussion first.

