### PR TITLE
Added support for RFC 9610

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Jam adheres to the following IETF standards:
 
 - [RFC 8620][jmap-rfc] - JMAP
 - [RFC 8621][jmap-mail-rfc] - JMAP for Mail
+- [RFC 9610][jmap-contacts-rfc] - JMAP for Contacts
 
 ### Table of Contents
 
@@ -444,6 +445,7 @@ sse.addEventListener("close", (event) => ...));
 [jmap-3.2-invocation]: https://datatracker.ietf.org/doc/html/rfc8620#section-3.2
 [jmap-3.7-result-refs]: https://datatracker.ietf.org/doc/html/rfc8620#section-3.7
 [jmap-5-std-methods]: https://datatracker.ietf.org/doc/html/rfc8620#section-5
+[jmap-contacts-rfc]: https://datatracker.ietf.org/doc/html/rfc9610
 [jmap-mail-rfc]: https://datatracker.ietf.org/doc/html/rfc8621
 [jmap-rfc]: https://datatracker.ietf.org/doc/html/rfc8620
 [mdn-esm]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules

--- a/packages/jmap-jam/src/__test__/contacts.test-d.ts
+++ b/packages/jmap-jam/src/__test__/contacts.test-d.ts
@@ -1,0 +1,170 @@
+import type {
+  AddressBook,
+  ContactCard,
+  CopySetError,
+  QueryResponse,
+  SetError
+} from "jmap-rfc-types";
+import { describe, expectTypeOf, it } from "vitest";
+import { JamClient } from "../client.ts";
+
+const jam = new JamClient({
+  bearerToken: "example",
+  sessionUrl: "https://example.com/jmap"
+});
+
+describe("AddressBook methods", () => {
+  it("AddressBook/get returns address books", async () => {
+    const [result] = await jam.api.AddressBook.get({
+      accountId: "account-1",
+      ids: ["book-1"]
+    });
+
+    expectTypeOf(result.list).toEqualTypeOf<ReadonlyArray<AddressBook>>();
+    expectTypeOf(result.state).toBeString();
+    expectTypeOf(result.notFound).toEqualTypeOf<ReadonlyArray<string>>();
+  });
+
+  it("AddressBook/get filters by properties", async () => {
+    const [result] = await jam.api.AddressBook.get({
+      accountId: "account-1",
+      properties: ["name", "sortOrder"]
+    });
+
+    expectTypeOf(result.list).toEqualTypeOf<
+      ReadonlyArray<Pick<AddressBook, "name" | "sortOrder">>
+    >();
+  });
+
+  it("AddressBook/set supports onSuccessSetIsDefault", async () => {
+    const [result] = await jam.api.AddressBook.set({
+      accountId: "account-1",
+      create: {
+        newBook: {
+          name: "Personal Contacts"
+        }
+      },
+      onSuccessSetIsDefault: "#newBook"
+    });
+
+    expectTypeOf(result.created).toExtend<{
+      newBook?: AddressBook;
+    }>();
+    expectTypeOf(result.notCreated).toEqualTypeOf<{
+      newBook?: SetError;
+    } | null>();
+  });
+
+  it("AddressBook/set supports onDestroyRemoveContents", async () => {
+    await jam.api.AddressBook.set({
+      accountId: "account-1",
+      destroy: ["book-1"],
+      onDestroyRemoveContents: true
+    });
+  });
+
+  it("AddressBook/changes returns standard changes response", async () => {
+    const [result] = await jam.api.AddressBook.changes({
+      accountId: "account-1",
+      sinceState: "state-1"
+    });
+
+    expectTypeOf(result.oldState).toBeString();
+    expectTypeOf(result.newState).toBeString();
+    expectTypeOf(result.created).toEqualTypeOf<string[]>();
+    expectTypeOf(result.updated).toEqualTypeOf<string[]>();
+    expectTypeOf(result.destroyed).toEqualTypeOf<string[]>();
+  });
+});
+
+describe("ContactCard methods", () => {
+  it("ContactCard/get returns contact cards", async () => {
+    const [result] = await jam.api.ContactCard.get({
+      accountId: "account-1",
+      ids: ["contact-1"]
+    });
+
+    expectTypeOf(result.list).toEqualTypeOf<ReadonlyArray<ContactCard>>();
+    expectTypeOf(result.state).toBeString();
+  });
+
+  it("ContactCard/set creates and updates contacts", async () => {
+    const [result] = await jam.api.ContactCard.set({
+      accountId: "account-1",
+      create: {
+        newContact: {
+          addressBookIds: {
+            "book-1": true
+          },
+          name: {
+            components: [
+              { kind: "given", value: "Jane" },
+              { kind: "surname", value: "Doe" }
+            ]
+          },
+          emails: {
+            email1: {
+              address: "jane@example.com",
+              contexts: { work: true }
+            }
+          }
+        }
+      }
+    });
+
+    expectTypeOf(result.created).toExtend<{
+      newContact?: ContactCard;
+    }>();
+    expectTypeOf(result.notCreated).toEqualTypeOf<{
+      newContact?: SetError;
+    } | null>();
+  });
+
+  it("ContactCard/query supports filtering", async () => {
+    const [result] = await jam.api.ContactCard.query({
+      accountId: "account-1",
+      filter: {
+        inAddressBook: "book-1",
+        email: "jane@example.com",
+        name: "Jane",
+        "name/given": "Jane",
+        text: "engineer"
+      }
+    });
+
+    expectTypeOf(result).toEqualTypeOf<QueryResponse>();
+  });
+
+  it("ContactCard/copy copies contacts between accounts", async () => {
+    const [result] = await jam.api.ContactCard.copy({
+      fromAccountId: "account-1",
+      accountId: "account-2",
+      create: {
+        copyContact: {
+          id: "contact-1",
+          addressBookIds: {
+            "book-2": true
+          }
+        }
+      }
+    });
+
+    expectTypeOf(result.created).toEqualTypeOf<
+      Record<string, ContactCard> | null
+    >();
+    expectTypeOf(result.notCreated).toEqualTypeOf<
+      Record<string, CopySetError> | null
+    >();
+  });
+});
+
+describe("Contacts capability", () => {
+  it("includes contacts capability in known capabilities", () => {
+    expectTypeOf(jam.capabilities.get("AddressBook")).toEqualTypeOf<
+      string | undefined
+    >();
+    expectTypeOf(jam.capabilities.get("ContactCard")).toEqualTypeOf<
+      string | undefined
+    >();
+  });
+});

--- a/packages/jmap-jam/src/capabilities.ts
+++ b/packages/jmap-jam/src/capabilities.ts
@@ -11,7 +11,10 @@ export const knownCapabilities = {
   SearchSnippet: "urn:ietf:params:jmap:mail",
   Identity: "urn:ietf:params:jmap:submission",
   EmailSubmission: "urn:ietf:params:jmap:submission",
-  VacationResponse: "urn:ietf:params:jmap:vacationresponse"
+  VacationResponse: "urn:ietf:params:jmap:vacationresponse",
+  // RFC9610
+  AddressBook: "urn:ietf:params:jmap:contacts",
+  ContactCard: "urn:ietf:params:jmap:contacts"
 };
 
 /**

--- a/packages/jmap-jam/src/contracts.ts
+++ b/packages/jmap-jam/src/contracts.ts
@@ -1,8 +1,13 @@
 import type {
+  AddressBook,
+  AddressBookCreate,
   BlobCopyArguments,
   BlobCopyResponse,
   ChangesArguments,
   ChangesResponse,
+  ContactCard,
+  ContactCardCreate,
+  ContactCardFilterCondition,
   CopyArguments,
   CopyResponse,
   Email,
@@ -54,6 +59,25 @@ export type Requests = {
   "PushSubscription/set": Omit<
     SetArguments<PushSubscriptionCreate>,
     "accountId" | "ifInState"
+  >;
+  // AddressBook ----------------------------
+  "AddressBook/get": GetArguments<AddressBook>;
+  "AddressBook/changes": ChangesArguments;
+  "AddressBook/set": SetArguments<AddressBookCreate> & {
+    onDestroyRemoveContents?: boolean;
+    onSuccessSetIsDefault?: ID | null;
+  };
+  // ContactCard ----------------------------
+  "ContactCard/get": GetArguments<ContactCard>;
+  "ContactCard/changes": ChangesArguments;
+  "ContactCard/query": QueryArguments<ContactCard, ContactCardFilterCondition>;
+  "ContactCard/queryChanges": QueryChangesArguments<
+    ContactCard,
+    ContactCardFilterCondition
+  >;
+  "ContactCard/set": SetArguments<ContactCardCreate>;
+  "ContactCard/copy": CopyArguments<
+    Pick<ContactCard, "id" | "addressBookIds">
   >;
   // Mailbox --------------------------------
   "Mailbox/get": GetArguments<Mailbox>;
@@ -151,6 +175,17 @@ export type Responses<A> = HasAllKeysOfRelated<
       SetResponse<PushSubscription, A>,
       "accountId" | "oldState" | "newState"
     >;
+    // AddressBook ----------------------------
+    "AddressBook/get": GetResponse<AddressBook, A>;
+    "AddressBook/changes": ChangesResponse;
+    "AddressBook/set": SetResponse<AddressBook, A>;
+    // ContactCard ----------------------------
+    "ContactCard/get": GetResponse<ContactCard, A>;
+    "ContactCard/changes": ChangesResponse;
+    "ContactCard/query": QueryResponse;
+    "ContactCard/queryChanges": QueryChangesResponse;
+    "ContactCard/set": SetResponse<ContactCard, A>;
+    "ContactCard/copy": CopyResponse<ContactCard>;
     // Mailbox --------------------------------
     "Mailbox/get": GetResponse<Mailbox, A>;
     "Mailbox/changes": ChangesResponse & {

--- a/packages/jmap-rfc-types/README.md
+++ b/packages/jmap-rfc-types/README.md
@@ -13,12 +13,14 @@ This package contains TypeScript types modeled upon the JMAP[^1] RFCs.
 
 ## Overview
 
-| RFC                                 | Types                                |
-| ----------------------------------- | ------------------------------------ |
-| [RFC 8620: JMAP][jmap-rfc]          | [`jmap.ts`](./lib/jmap.ts)           |
-| [RFC 8621: JMAP for Mail][mail-rfc] | [`jmap-mail.ts`](./lib/jmap-mail.ts) |
+| RFC                                         | Types                                        |
+| ------------------------------------------- | -------------------------------------------- |
+| [RFC 8620: JMAP][jmap-rfc]                  | [`jmap.ts`](./lib/jmap.ts)                   |
+| [RFC 8621: JMAP for Mail][mail-rfc]         | [`jmap-mail.ts`](./lib/jmap-mail.ts)         |
+| [RFC 9610: JMAP for Contacts][contacts-rfc] | [`jmap-contacts.ts`](./lib/jmap-contacts.ts) |
 
 [jmap-rfc]: https://datatracker.ietf.org/doc/html/rfc8620
 [mail-rfc]: https://datatracker.ietf.org/doc/html/rfc8621
+[contacts-rfc]: https://datatracker.ietf.org/doc/html/rfc9610
 
 [^1]: JSON Meta Application Protocol

--- a/packages/jmap-rfc-types/lib/__test__/jmap-contacts.test-d.ts
+++ b/packages/jmap-rfc-types/lib/__test__/jmap-contacts.test-d.ts
@@ -4,13 +4,11 @@ import type {
   ContactCard,
   ContactCardFilterCondition,
   ContactEmailAddress,
-  JMAPContacts
+  Entities
 } from "../jmap-contacts.ts";
 
 describe("JMAPContacts types", () => {
   it("defines correct entity types", () => {
-    type Entities = JMAPContacts.Entities;
-    
     expectTypeOf<Entities>().toEqualTypeOf<{
       AddressBook: AddressBook;
       ContactCard: ContactCard;

--- a/packages/jmap-rfc-types/lib/__test__/jmap-contacts.test-d.ts
+++ b/packages/jmap-rfc-types/lib/__test__/jmap-contacts.test-d.ts
@@ -1,0 +1,84 @@
+import { describe, expectTypeOf, it } from "vitest";
+import type {
+  AddressBook,
+  ContactCard,
+  ContactCardFilterCondition,
+  ContactEmailAddress,
+  JMAPContacts
+} from "../jmap-contacts.ts";
+
+describe("JMAPContacts types", () => {
+  it("defines correct entity types", () => {
+    type Entities = JMAPContacts.Entities;
+    
+    expectTypeOf<Entities>().toEqualTypeOf<{
+      AddressBook: AddressBook;
+      ContactCard: ContactCard;
+    }>();
+  });
+
+  it("AddressBook has required properties", () => {
+    const addressBook: AddressBook = {
+      id: "test-id",
+      name: "Personal",
+      description: null,
+      sortOrder: 0,
+      isDefault: true,
+      isSubscribed: true,
+      shareWith: null,
+      myRights: {
+        mayRead: true,
+        mayWrite: true,
+        mayShare: false,
+        mayDelete: false
+      }
+    };
+
+    expectTypeOf(addressBook.id).toBeString();
+    expectTypeOf(addressBook.name).toBeString();
+    expectTypeOf(addressBook.sortOrder).toBeNumber();
+  });
+
+  it("ContactCard has JSContact properties plus JMAP extensions", () => {
+    const contact: ContactCard = {
+      id: "contact-1",
+      addressBookIds: {
+        "addressbook-1": true
+      },
+      name: {
+        components: [
+          { kind: "given", value: "Jane" },
+          { kind: "surname", value: "Doe" }
+        ]
+      }
+    };
+
+    expectTypeOf(contact.id).toBeString();
+    expectTypeOf(contact.addressBookIds).toEqualTypeOf<Record<string, true>>();
+  });
+
+  it("ContactEmailAddress is distinct from mail EmailAddress", () => {
+    const email: ContactEmailAddress = {
+      address: "test@example.com",
+      label: "Work",
+      contexts: { work: true },
+      pref: 1
+    };
+
+    expectTypeOf(email.address).toBeString();
+    expectTypeOf(email.label).toEqualTypeOf<string | undefined>();
+  });
+
+  it("ContactCardFilterCondition supports all search fields", () => {
+    const filter: ContactCardFilterCondition = {
+      inAddressBook: "book-1",
+      email: "test@example.com",
+      name: "Jane",
+      "name/given": "Jane",
+      text: "software engineer"
+    };
+
+    expectTypeOf(filter.inAddressBook).toEqualTypeOf<string | undefined>();
+    expectTypeOf(filter.email).toEqualTypeOf<string | undefined>();
+  });
+});

--- a/packages/jmap-rfc-types/lib/index.ts
+++ b/packages/jmap-rfc-types/lib/index.ts
@@ -1,2 +1,3 @@
+export * from "./jmap-contacts.ts";
 export * from "./jmap-mail.ts";
 export * from "./jmap.ts";

--- a/packages/jmap-rfc-types/lib/jmap-contacts.ts
+++ b/packages/jmap-rfc-types/lib/jmap-contacts.ts
@@ -1,0 +1,715 @@
+import type { FilterCondition, ID, UTCDate } from "./jmap.ts";
+
+/**
+ * JMAP Contacts
+ *
+ * [rfc9610](https://datatracker.ietf.org/doc/html/rfc9610)
+ */
+
+export namespace JMAPContacts {
+  export type Entities = {
+    AddressBook: AddressBook;
+    ContactCard: ContactCard;
+  };
+
+  export type Entity = keyof Entities;
+}
+
+// =================================
+// AddressBooks
+// =================================
+
+/**
+ * [rfc9610 § 2](https://datatracker.ietf.org/doc/html/rfc9610#section-2)
+ *
+ * An AddressBook is a named collection of ContactCards. All ContactCards are
+ * associated with one or more AddressBooks.
+ */
+export type AddressBook = {
+  /**
+   * The id of the AddressBook.
+   *
+   * @kind immutable
+   * @kind server-set
+   */
+  id: ID;
+  /**
+   * The user-visible name of the AddressBook. This MUST NOT be the empty
+   * string and MUST NOT be greater than 255 octets in size when encoded as UTF-8.
+   */
+  name: string;
+  /**
+   * An optional long-form description of the AddressBook that provides
+   * context in shared environments where users need more than just the name.
+   */
+  description: string | null;
+  /**
+   * Defines the sort order of AddressBooks when presented in the client's UI
+   * so it is consistent between devices. The number MUST be an integer in the
+   * range 0 <= sortOrder < 2^31.
+   */
+  sortOrder: number;
+  /**
+   * This SHOULD be true for exactly one AddressBook in any account and MUST
+   * NOT be true for more than one AddressBook within an account.
+   *
+   * @kind server-set
+   */
+  isDefault: boolean;
+  /**
+   * True if the user has indicated they wish to see this AddressBook in their
+   * client.
+   */
+  isSubscribed: boolean;
+  /**
+   * A map of the Principal id to rights for Principals this AddressBook is
+   * shared with. The Principal to which this AddressBook belongs MUST NOT be
+   * in this set. This is null if the AddressBook is not shared with anyone or
+   * if the server does not support RFC 9670.
+   */
+  shareWith: Record<ID, AddressBookRights> | null;
+  /**
+   * The set of access rights the user has in relation to this AddressBook.
+   *
+   * @kind server-set
+   */
+  myRights: AddressBookRights;
+};
+
+export type AddressBookCreate = Omit<
+  AddressBook,
+  // Fields set by server
+  | "id"
+  | "isDefault"
+  | "myRights"
+>;
+
+/**
+ * [rfc9610 § 2](https://datatracker.ietf.org/doc/html/rfc9610#section-2)
+ *
+ * An AddressBookRights object has the following properties.
+ */
+export type AddressBookRights = {
+  /**
+   * The user may fetch the ContactCards in this AddressBook.
+   */
+  mayRead: boolean;
+  /**
+   * The user may create, modify, or destroy all ContactCards in this
+   * AddressBook, or move them to or from this AddressBook.
+   */
+  mayWrite: boolean;
+  /**
+   * The user may modify the "shareWith" property for this AddressBook.
+   */
+  mayShare: boolean;
+  /**
+   * The user may delete the AddressBook itself.
+   */
+  mayDelete: boolean;
+};
+
+// =================================
+// ContactCards
+// =================================
+
+/**
+ * [rfc9610 § 3](https://datatracker.ietf.org/doc/html/rfc9610#section-3)
+ *
+ * A ContactCard object contains information about a person, company, or other
+ * entity, or represents a group of such entities. It is a JSContact Card
+ * object as defined in RFC 9553 with additional JMAP-specific properties.
+ */
+export type ContactCard = JSContactCard & {
+  /**
+   * The id of the ContactCard. The "id" property MAY be different to the
+   * ContactCard's "uid" property. However, there MUST NOT be more than one
+   * ContactCard with the same uid in an Account.
+   *
+   * @kind immutable
+   * @kind server-set
+   */
+  id: ID;
+  /**
+   * The set of AddressBook ids that this ContactCard belongs to. A card MUST
+   * belong to at least one AddressBook at all times (until it is destroyed).
+   * The set is represented as an object, with each key being an AddressBook id.
+   * The value for each key in the object MUST be true.
+   */
+  addressBookIds: Record<ID, true>;
+};
+
+export type ContactCardCreate = Omit<ContactCard, "id">;
+
+/**
+ * Base JSContact Card object as defined in RFC 9553.
+ * This is a simplified type definition covering the most common properties.
+ * For full RFC 9553 compliance, you may need to extend this type.
+ */
+export type JSContactCard = {
+  /**
+   * The version of the JSContact specification this card conforms to.
+   */
+  "@type"?: "Card";
+  /**
+   * The version of JSContact.
+   */
+  version?: string;
+  /**
+   * A globally unique identifier for this card.
+   */
+  uid?: string;
+  /**
+   * The kind of entity this card represents.
+   */
+  kind?: "individual" | "group" | "org" | "location" | "device" | "application";
+  /**
+   * The creation date-time of this card.
+   */
+  created?: UTCDate;
+  /**
+   * The last update date-time of this card.
+   */
+  updated?: UTCDate;
+  /**
+   * The language tag of the primary language for this card.
+   */
+  language?: string;
+  /**
+   * UIDs of other cards that are members of this group (for kind="group").
+   */
+  members?: Record<string, boolean>;
+  /**
+   * The name components of the entity.
+   */
+  name?: Name;
+  /**
+   * Alternative names or nicknames.
+   */
+  nicknames?: Record<string, Nickname>;
+  /**
+   * Organizations the entity is affiliated with.
+   */
+  organizations?: Record<string, Organization>;
+  /**
+   * Job titles of the entity.
+   */
+  titles?: Record<string, Title>;
+  /**
+   * Email addresses.
+   */
+  emails?: Record<string, ContactEmailAddress>;
+  /**
+   * Phone numbers.
+   */
+  phones?: Record<string, Phone>;
+  /**
+   * Online service accounts.
+   */
+  onlineServices?: Record<string, OnlineService>;
+  /**
+   * Preferred contact methods.
+   */
+  preferredContactMethod?: string;
+  /**
+   * Postal addresses.
+   */
+  addresses?: Record<string, Address>;
+  /**
+   * Anniversary dates.
+   */
+  anniversaries?: Record<string, Anniversary>;
+  /**
+   * Personal information.
+   */
+  personalInfo?: Record<string, PersonalInfo>;
+  /**
+   * Notes or additional information.
+   */
+  notes?: Record<string, Note>;
+  /**
+   * Categories or tags.
+   */
+  categories?: Record<string, boolean>;
+  /**
+   * Photos or avatars.
+   */
+  photos?: Record<string, Media>;
+  /**
+   * Related links or URLs.
+   */
+  links?: Record<string, Link>;
+  /**
+   * Keywords for indexing and searching.
+   */
+  keywords?: Record<string, boolean>;
+  /**
+   * Localized versions of this card.
+   */
+  localizations?: Record<string, ContactPatchObject>;
+};
+
+/**
+ * Name components as defined in RFC 9553.
+ */
+export type Name = {
+  /**
+   * Name components that make up the full name.
+   */
+  components?: NameComponent[];
+  /**
+   * The full name as a single string.
+   */
+  full?: string;
+  /**
+   * Sort order string for this name.
+   */
+  sortAs?: Record<string, string>;
+  /**
+   * Default separator for joining name components.
+   */
+  defaultSeparator?: string;
+  /**
+   * Whether the components are ordered.
+   */
+  isOrdered?: boolean;
+  /**
+   * Phonetic representation.
+   */
+  phoneticScript?: string;
+  /**
+   * Phonetic system used.
+   */
+  phoneticSystem?: string;
+};
+
+export type NameComponent = {
+  /**
+   * The kind of name component.
+   */
+  kind?:
+    | "prefix"
+    | "given"
+    | "given2"
+    | "surname"
+    | "surname2"
+    | "suffix"
+    | "credential";
+  /**
+   * The value of this name component.
+   */
+  value: string;
+  /**
+   * Phonetic representation.
+   */
+  phonetic?: string;
+};
+
+export type Nickname = {
+  /**
+   * The nickname value.
+   */
+  name: string;
+  /**
+   * Contexts in which this nickname applies.
+   */
+  contexts?: Record<string, boolean>;
+  /**
+   * Preference order.
+   */
+  pref?: number;
+};
+
+export type Organization = {
+  /**
+   * The organization name.
+   */
+  name: string;
+  /**
+   * Units or divisions within the organization.
+   */
+  units?: string[];
+  /**
+   * Sort order string.
+   */
+  sortAs?: string;
+  /**
+   * Contexts in which this organization applies.
+   */
+  contexts?: Record<string, boolean>;
+};
+
+export type Title = {
+  /**
+   * The job title or role.
+   */
+  title: string;
+  /**
+   * The organization this title is with.
+   */
+  organizationId?: string;
+  /**
+   * Contexts in which this title applies.
+   */
+  contexts?: Record<string, boolean>;
+};
+
+export type ContactEmailAddress = {
+  /**
+   * The email address.
+   */
+  address: string;
+  /**
+   * A label for this email address.
+   */
+  label?: string;
+  /**
+   * Contexts in which this email applies.
+   */
+  contexts?: Record<string, boolean>;
+  /**
+   * Preference order.
+   */
+  pref?: number;
+};
+
+export type Phone = {
+  /**
+   * The phone number.
+   */
+  number: string;
+  /**
+   * A label for this phone number.
+   */
+  label?: string;
+  /**
+   * Features of this phone number.
+   */
+  features?: Record<string, boolean>;
+  /**
+   * Contexts in which this phone applies.
+   */
+  contexts?: Record<string, boolean>;
+  /**
+   * Preference order.
+   */
+  pref?: number;
+};
+
+export type OnlineService = {
+  /**
+   * The service name (e.g., "twitter", "skype").
+   */
+  service?: string;
+  /**
+   * The URI for this service.
+   */
+  uri?: string;
+  /**
+   * The username or handle.
+   */
+  user?: string;
+  /**
+   * A label for this service.
+   */
+  label?: string;
+  /**
+   * Contexts in which this service applies.
+   */
+  contexts?: Record<string, boolean>;
+  /**
+   * Preference order.
+   */
+  pref?: number;
+};
+
+export type Address = {
+  /**
+   * Address components.
+   */
+  components?: AddressComponent[];
+  /**
+   * The full address as a single string.
+   */
+  full?: string;
+  /**
+   * Contexts in which this address applies.
+   */
+  contexts?: Record<string, boolean>;
+  /**
+   * Preference order.
+   */
+  pref?: number;
+  /**
+   * Coordinates of this address.
+   */
+  coordinates?: string;
+  /**
+   * Time zone of this address.
+   */
+  timeZone?: string;
+};
+
+export type AddressComponent = {
+  /**
+   * The kind of address component.
+   */
+  kind?:
+    | "room"
+    | "apartment"
+    | "floor"
+    | "building"
+    | "number"
+    | "name"
+    | "block"
+    | "subdistrict"
+    | "district"
+    | "locality"
+    | "region"
+    | "postcode"
+    | "country"
+    | "direction"
+    | "landmark"
+    | "postOfficeBox"
+    | "separator";
+  /**
+   * The value of this address component.
+   */
+  value: string;
+};
+
+export type Anniversary = {
+  /**
+   * The type of anniversary.
+   */
+  kind?: "birth" | "death" | "wedding" | string;
+  /**
+   * The date of the anniversary.
+   */
+  date: PartialDate;
+  /**
+   * The place associated with this anniversary.
+   */
+  place?: Address;
+};
+
+export type PartialDate = {
+  /**
+   * Year (4 digits).
+   */
+  year?: number;
+  /**
+   * Month (1-12).
+   */
+  month?: number;
+  /**
+   * Day (1-31).
+   */
+  day?: number;
+};
+
+export type PersonalInfo = {
+  /**
+   * The kind of personal information.
+   */
+  kind: "expertise" | "hobby" | "interest" | string;
+  /**
+   * The value of this personal information.
+   */
+  value: string;
+  /**
+   * Level of expertise (1-3).
+   */
+  level?: "beginner" | "average" | "expert";
+};
+
+export type Note = {
+  /**
+   * The note text.
+   */
+  note: string;
+  /**
+   * The author of this note.
+   */
+  author?: string;
+  /**
+   * Creation date of this note.
+   */
+  created?: UTCDate;
+};
+
+/**
+ * Media object for photos, logos, and other media.
+ *
+ * [rfc9610 § 3](https://datatracker.ietf.org/doc/html/rfc9610#section-3)
+ */
+export type Media = {
+  /**
+   * The kind of media.
+   */
+  kind?: "photo" | "logo" | "sound";
+  /**
+   * The URI of the media resource.
+   */
+  uri?: string;
+  /**
+   * An id for the Blob representing the binary contents of the resource
+   * (JMAP-specific property).
+   */
+  blobId?: ID;
+  /**
+   * The media type.
+   */
+  mediaType?: string;
+  /**
+   * Contexts in which this media applies.
+   */
+  contexts?: Record<string, boolean>;
+  /**
+   * Preference order.
+   */
+  pref?: number;
+};
+
+export type Link = {
+  /**
+   * The URI of the link.
+   */
+  uri: string;
+  /**
+   * The kind of resource.
+   */
+  kind?: "contact" | "other";
+  /**
+   * Media type of the linked resource.
+   */
+  mediaType?: string;
+  /**
+   * Label for this link.
+   */
+  label?: string;
+  /**
+   * Contexts in which this link applies.
+   */
+  contexts?: Record<string, boolean>;
+  /**
+   * Preference order.
+   */
+  pref?: number;
+};
+
+export type ContactPatchObject = Record<string, unknown>;
+
+// =================================
+// Filter Conditions
+// =================================
+
+/**
+ * [rfc9610 § 3.3.1](https://datatracker.ietf.org/doc/html/rfc9610#section-3.3.1)
+ *
+ * Filter conditions for ContactCard/query.
+ */
+export type ContactCardFilterCondition = FilterCondition<{
+  /**
+   * An AddressBook id. A card must be in this address book to match the condition.
+   */
+  inAddressBook?: ID;
+  /**
+   * A card must have this string exactly as its uid to match.
+   */
+  uid?: string;
+  /**
+   * A card must have a "members" property that contains this string as one of
+   * the uids in the set to match.
+   */
+  hasMember?: string;
+  /**
+   * A card must have a "kind" property that equals this string exactly to match.
+   */
+  kind?: string;
+  /**
+   * The "created" date-time of the ContactCard must be before this date-time.
+   */
+  createdBefore?: UTCDate;
+  /**
+   * The "created" date-time of the ContactCard must be the same or after this date-time.
+   */
+  createdAfter?: UTCDate;
+  /**
+   * The "updated" date-time of the ContactCard must be before this date-time.
+   */
+  updatedBefore?: UTCDate;
+  /**
+   * The "updated" date-time of the ContactCard must be the same or after this date-time.
+   */
+  updatedAfter?: UTCDate;
+  /**
+   * A card matches if the text matches with text in the card.
+   */
+  text?: string;
+  /**
+   * Matches the value of any NameComponent in the "name" property or the "full" property.
+   */
+  name?: string;
+  /**
+   * Matches a NameComponent with kind "given".
+   */
+  "name/given"?: string;
+  /**
+   * Matches a NameComponent with kind "surname".
+   */
+  "name/surname"?: string;
+  /**
+   * Matches a NameComponent with kind "surname2".
+   */
+  "name/surname2"?: string;
+  /**
+   * Matches the "name" of any Nickname.
+   */
+  nickname?: string;
+  /**
+   * Matches the "name" of any Organization.
+   */
+  organization?: string;
+  /**
+   * Matches the "address" or "label" of any EmailAddress.
+   */
+  email?: string;
+  /**
+   * Matches the "number" or "label" of any Phone.
+   */
+  phone?: string;
+  /**
+   * Matches the "service", "uri", "user", or "label" of any OnlineService.
+   */
+  onlineService?: string;
+  /**
+   * Matches the value of any AddressComponent or the "full" property in addresses.
+   */
+  address?: string;
+  /**
+   * Matches the "note" of any Note.
+   */
+  note?: string;
+}>;
+
+// =================================
+// Capability
+// =================================
+
+/**
+ * [rfc9610 § 1.4.1](https://datatracker.ietf.org/doc/html/rfc9610#section-1.4.1)
+ *
+ * Capability for urn:ietf:params:jmap:contacts
+ */
+export type ContactsCapability = {
+  /**
+   * The maximum number of AddressBooks that can be assigned to a single
+   * ContactCard object. This MUST be an integer >= 1, or null for no limit.
+   */
+  maxAddressBooksPerCard: number | null;
+  /**
+   * The user may create an AddressBook in this account if, and only if, this is true.
+   */
+  mayCreateAddressBook: boolean;
+};

--- a/packages/jmap-rfc-types/package.json
+++ b/packages/jmap-rfc-types/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "exports": {
     ".": "./lib/index.ts",
+    "./jmap-contacts": "./lib/jmap-contacts.ts",
     "./jmap-mail": "./lib/jmap-mail.ts",
     "./jmap": "./lib/jmap.ts"
   },


### PR DESCRIPTION
Closes #115 

This PR maps RFC 9610 specification into typescript, maintaining the style and design in this package. The only deviation is that it opts to also expose the interface `JSContactCard` from RFC 9553, as `ContactCard` is specified on top of this construct.

It:

* adds code (rfc-types and attributes to the contract)
* updates documentation and
* adds tests

NOTE: This PR was implemented with the help of Claude 4.5, and reviewed with the help of Claude 4.6. I read and understood all changes in the PR.
